### PR TITLE
Adjust gap between <p> and <ul>

### DIFF
--- a/_sass/_karina.scss
+++ b/_sass/_karina.scss
@@ -3,3 +3,14 @@
 p {
   margin-top: 8px;
 }
+
+// This reduces the gap between any <ul> that immediately follows a <p>. The "margin-top" of the ul
+// was already zero by default, so we apply a negative margin to pull the ul list up a bit.
+// On small screens this looked best at 10px. On larger screens 15px.
+@media #{$small-only} {
+  p + ul { margin-top: -10px; }
+}
+@media #{$medium-up} {
+  p + ul { margin-top: -15px; }
+}
+


### PR DESCRIPTION
This reduces the gap between any `<ul>` that immediately follows a `<p>`. The "margin-top" of the ul was already zero by default, so we apply a negative margin to pull the ul list up a bit. On small screens this looked best at 10px. On larger screens 15px.

Before:

![image](https://user-images.githubusercontent.com/299102/123510065-4dcf1e80-d671-11eb-87df-d394ecdeb9d0.png)


After:

![image](https://user-images.githubusercontent.com/299102/123510052-3ee86c00-d671-11eb-8380-65499a7b9815.png)
