### PR TITLE
Remove gap above h3

### DIFF
--- a/_layouts/kz-frontpage.html
+++ b/_layouts/kz-frontpage.html
@@ -91,7 +91,7 @@ format: frontpage
 
         <!-- List of earlier pages -->
         <div class="medium-6 columns">
-            <h3>Recently published:</h3>
+            <h3 style="margin-top: 0px;">Recently published:</h3>
             <ul class="side-nav">
                 {% for post in site.posts limit:7 %}
                     {% unless post.primary_post == true %}


### PR DESCRIPTION
This removes the gap above "Recently published"